### PR TITLE
Revert resample_df handling and silence join warning

### DIFF
--- a/R/resampling_functions.R
+++ b/R/resampling_functions.R
@@ -136,7 +136,7 @@ check that all keys only have one stratification variable associated
     sample[[key_col_name]] <- 1:nrow(sample)
   }
   
-  # relationship arg added in dplyr 1.1.0
+  # relationship arg added in dplyr 1.1.1
   if (utils::packageVersion("dplyr") >= "1.1.1") {
     # Specify join relationship based on replacement to silence warning:
     #  "Detected an unexpected many-to-many relationship between `x` and `y`"

--- a/R/resampling_functions.R
+++ b/R/resampling_functions.R
@@ -135,7 +135,11 @@ check that all keys only have one stratification variable associated
     sample <- sample[, key_cols, drop=F] 
     sample[[key_col_name]] <- 1:nrow(sample)
   }
-  resampled_df <- dplyr::left_join(sample, df, by = key_cols)
+  
+  # Specify join relationship based on replacement to silence warning:
+  #  "Detected an unexpected many-to-many relationship between `x` and `y`"
+  relat <- if(isTRUE(replace)) "many-to-many" else NULL
+  resampled_df <- dplyr::left_join(sample, df, by = key_cols, relationship = relat)
   
   
   #reorder columns to match original df with key column appended

--- a/R/resampling_functions.R
+++ b/R/resampling_functions.R
@@ -137,7 +137,7 @@ check that all keys only have one stratification variable associated
   }
   
   # relationship arg added in dplyr 1.1.0
-  if (utils::packageVersion("dplyr") >= "1.1.0") {
+  if (utils::packageVersion("dplyr") >= "1.1.1") {
     # Specify join relationship based on replacement to silence warning:
     #  "Detected an unexpected many-to-many relationship between `x` and `y`"
     # - occurs when there are repeated key_cols in both data frames

--- a/R/resampling_functions.R
+++ b/R/resampling_functions.R
@@ -136,11 +136,16 @@ check that all keys only have one stratification variable associated
     sample[[key_col_name]] <- 1:nrow(sample)
   }
   
-  # Specify join relationship based on replacement to silence warning:
-  #  "Detected an unexpected many-to-many relationship between `x` and `y`"
-  relat <- if(isTRUE(replace)) "many-to-many" else NULL
-  resampled_df <- dplyr::left_join(sample, df, by = key_cols, relationship = relat)
-  
+  # relationship arg added in dplyr 1.1.0
+  if (utils::packageVersion("dplyr") >= "1.1.0") {
+    # Specify join relationship based on replacement to silence warning:
+    #  "Detected an unexpected many-to-many relationship between `x` and `y`"
+    # - occurs when there are repeated key_cols in both data frames
+    relat <- if(isTRUE(replace)) "many-to-many" else NULL
+    resampled_df <- dplyr::left_join(sample, df, by = key_cols, relationship = relat)
+  } else {
+    resampled_df <- dplyr::left_join(sample, df, by = key_cols)
+  }
   
   #reorder columns to match original df with key column appended
   return(resampled_df[,names, drop=F])

--- a/R/resampling_functions.R
+++ b/R/resampling_functions.R
@@ -135,20 +135,7 @@ check that all keys only have one stratification variable associated
     sample <- sample[, key_cols, drop=F] 
     sample[[key_col_name]] <- 1:nrow(sample)
   }
-  
-  resampled_df <- dplyr::tibble()
-  
-  for (i in 1:nrow(sample)) {
-    
-    resampled_df <-
-      dplyr::bind_rows(
-        resampled_df,
-        sample %>% 
-          dplyr::slice(i) %>% 
-          dplyr::inner_join(df)
-      )
-    
-  }
+  resampled_df <- dplyr::left_join(sample, df, by = key_cols)
   
   
   #reorder columns to match original df with key column appended

--- a/tests/testthat/test-resampling.R
+++ b/tests/testthat/test-resampling.R
@@ -1,15 +1,13 @@
 context("resampledf")
 
-
-dapa<- sd_oral_richpk %>% capitalize_names() %>%
-  dplyr::filter(TIME %in% c(0, 0.5), ID %in% 5:7)%>%
-  dplyr::select(ID, AGE, TIME)
-
-no_extras <- resample_df(dapa, key_cols = "ID", strat_cols = "AGE", key_col_name = "Key", n=5) 
-has_extras <- resample_df(dapa, key_cols = "ID", strat_cols = "AGE", key_col_name = "Key", n=10)
-
-
 test_that("resample_df properly recombines when it needs to make extra draws", {
+  dapa <- sd_oral_richpk %>% capitalize_names() %>%
+    dplyr::filter(TIME %in% c(0, 0.5), ID %in% 5:7)%>%
+    dplyr::select(ID, AGE, TIME)
+  
+  no_extras <- resample_df(dapa, key_cols = "ID", strat_cols = "AGE", key_col_name = "Key", n=5) 
+  has_extras <- resample_df(dapa, key_cols = "ID", strat_cols = "AGE", key_col_name = "Key", n=10)
+  
   expect_equal(nrow(no_extras), 10)
   expect_equal(dplyr::n_distinct(no_extras$Key), 5)
   expect_equal(nrow(has_extras), 20)


### PR DESCRIPTION
The latest resample_df refactor done in https://github.com/metrumresearchgroup/mrgmisc/pull/51 caused unnecessary join messages and hurt performance to a notable degree. This is especially relevant for `bbr` bootstrap setup.

This PR does the following
 - Revert the core changes done in #51 
 - Ensure the original warning intended to be fixed is silenced. It appeared in the test suite, though never appeared in a `bbr` context.


closes https://github.com/metrumresearchgroup/mrgmisc/issues/55