### PR TITLE
ids_per_plot: support IDs with attributes

### DIFF
--- a/R/chunking.R
+++ b/R/chunking.R
@@ -61,7 +61,9 @@ ids_per_plot <- function(id, id_per_plot = 9) {
   mod <- nuniq %/% id_per_plot
   rem <- nuniq %% id_per_plot
   bins <- c(rep(seq_len(mod), each = id_per_plot), rep(mod + 1, times = rem))
-  if(length(bins) != nuniq) stop("something went wrong in bins calculation")
+  if (length(bins) != nuniq) {
+    stop("bug: bins should always be same length as nuniq")
+  }
   bins[match(id, uid)]
 }
 

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -49,8 +49,8 @@ ids_per_plot <- function(id, id_per_plot = 9) {
     stop("chunking requires a vector")
   }
   uid <- unique(id)
-  if(length(uid) < id_per_plot) {
-    id_per_plot <- length(uid)
+  if (length(uid) <= id_per_plot) {
+    return(rep.int(1L, length(id)))
   }
   
   mod <- length(uid)%/%id_per_plot

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -49,11 +49,16 @@ ids_per_plot <- function(id, id_per_plot = 9) {
     stop("id_per_plot must be at least 1")
   }
 
-  if(!is.vector(id)) {
-    stop("chunking requires a vector")
+  if (is.factor(id)) {
+    xs <- factor(id) # Drop any missing levels.
+  } else {
+    xs <- factor(id, levels = unique(id))
   }
-  uid <- unique(id)
-  nuniq <- length(uid)
+  nuniq <- nlevels(xs)
+
+  if (nuniq == 0) {
+    return(integer())
+  }
   if (nuniq <= id_per_plot) {
     return(rep.int(1L, length(id)))
   }
@@ -64,7 +69,9 @@ ids_per_plot <- function(id, id_per_plot = 9) {
   if (length(bins) != nuniq) {
     stop("bug: bins should always be same length as nuniq")
   }
-  bins[match(id, uid)]
+  levels(xs) <- bins
+
+  return(as.integer(xs))
 }
 
 

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -57,12 +57,11 @@ ids_per_plot <- function(id, id_per_plot = 9) {
     return(rep.int(1L, length(id)))
   }
   
-  mod <- length(uid)%/%id_per_plot
-  remainder <- length(uid)%%id_per_plot
-  bin_number <- c(rep(1:mod, each= id_per_plot),
-                  rep(mod + 1, times = remainder ))
-  if(length(bin_number) != length(uid)) stop("something went wrong in bin_number calculation")
-  bin_number[match(id, uid)]
+  mod <- length(uid) %/% id_per_plot
+  rem <- length(uid) %% id_per_plot
+  bins <- c(rep(1:mod, each= id_per_plot), rep(mod + 1, times = rem))
+  if(length(bins) != length(uid)) stop("something went wrong in bins calculation")
+  bins[match(id, uid)]
 }
 
 

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -53,14 +53,15 @@ ids_per_plot <- function(id, id_per_plot = 9) {
     stop("chunking requires a vector")
   }
   uid <- unique(id)
-  if (length(uid) <= id_per_plot) {
+  nuniq <- length(uid)
+  if (nuniq <= id_per_plot) {
     return(rep.int(1L, length(id)))
   }
-  
-  mod <- length(uid) %/% id_per_plot
-  rem <- length(uid) %% id_per_plot
-  bins <- c(rep(seq_len(mod), each= id_per_plot), rep(mod + 1, times = rem))
-  if(length(bins) != length(uid)) stop("something went wrong in bins calculation")
+
+  mod <- nuniq %/% id_per_plot
+  rem <- nuniq %% id_per_plot
+  bins <- c(rep(seq_len(mod), each = id_per_plot), rep(mod + 1, times = rem))
+  if(length(bins) != nuniq) stop("something went wrong in bins calculation")
   bins[match(id, uid)]
 }
 

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -59,7 +59,7 @@ ids_per_plot <- function(id, id_per_plot = 9) {
   
   mod <- length(uid) %/% id_per_plot
   rem <- length(uid) %% id_per_plot
-  bins <- c(rep(1:mod, each= id_per_plot), rep(mod + 1, times = rem))
+  bins <- c(rep(seq_len(mod), each= id_per_plot), rep(mod + 1, times = rem))
   if(length(bins) != length(uid)) stop("something went wrong in bins calculation")
   bins[match(id, uid)]
 }

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -57,7 +57,6 @@ ids_per_plot <- function(id, id_per_plot = 9) {
   remainder <- length(uid)%%id_per_plot
   bin_number <- c(rep(1:mod, each= id_per_plot),
                   rep(mod + 1, times = remainder ))
-  bin_number <- sort(bin_number)
   if(length(bin_number) != length(uid)) stop("something went wrong in bin_number calculation")
   bin_number[match(id, uid)]
 }

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -45,6 +45,10 @@ chunk <- function(.x, .nchunk = parallel::detectCores()) {
 #' @param id_per_plot number of ids per plot. Default to 9
 #'@export
 ids_per_plot <- function(id, id_per_plot = 9) {
+  if (id_per_plot < 1) {
+    stop("id_per_plot must be at least 1")
+  }
+
   if(!is.vector(id)) {
     stop("chunking requires a vector")
   }

--- a/tests/testthat/test-chunk.R
+++ b/tests/testthat/test-chunk.R
@@ -78,8 +78,61 @@ test_that("chunk with groups: Chunks grouped elements into ragged arrays", {
 
 # ID per plot -------------------------------------------------------------
 
-test_that("ids_per_plot expected output: Error occurs if input ID's are not vector", {
-  expect_error(ids_per_plot(Theoph$Subject[1], id_per_plot = 9), "chunking requires a vector")
+test_that("ids_per_plot: supports factors", {
+  expect_identical(
+    ids_per_plot(Theoph$Subject[1], id_per_plot = 9),
+    1L
+  )
+  expect_identical(
+    ids_per_plot(factor(letters), id_per_plot = 10),
+    c(
+      rep(1L, 10),
+      rep(2L, 10),
+      rep(3L, 6)
+    )
+  )
+  expect_identical(
+    ids_per_plot(factor(rep(letters, each = 2)), id_per_plot = 10),
+    c(
+      rep(1L, 20),
+      rep(2L, 20),
+      rep(3L, 12)
+    )
+  )
+  expect_identical(
+    ids_per_plot(factor(rev(letters)), id_per_plot = 10),
+    c(
+      rep(3L, 6),
+      rep(2L, 10),
+      rep(1L, 10)
+    )
+  )
+  expect_identical(
+    ids_per_plot(
+      factor(c(10L, 60L, 15L, 15L, 30L, 40L, 50L, 20L)),
+      id_per_plot = 3
+    ),
+    c(1L, 3L, 1L, 1L, 2L, 2L, 2L, 1L)
+  )
+  expect_identical(
+    ids_per_plot(
+      factor(c(1.1, 2.2, 2.1, 2.1, 3.3, 4.4, 5.5, 6.6)),
+      id_per_plot = 3
+    ),
+    c(1L, 1L, 1L, 1L, 2L, 2L, 2L, 3L)
+  )
+  expect_identical(
+    ids_per_plot(factor(letters))[0],
+    integer()
+  )
+  # Keeps existing levels.
+  expect_identical(
+    ids_per_plot(
+      factor(c("a", "b", "c", "d", "a", "b"), levels = c("d", "c", "a", "b")),
+      id_per_plot = 2
+    ),
+    c(2L, 2L, 1L, 1L, 2L, 2L)
+  )
 })
 
 test_that("ids_per_plot expected output: IDs are sorted properly", {
@@ -93,6 +146,10 @@ test_that("ids_per_plot special case: no error if more bins provided than values
   expect_equal(ids_per_plot(c(1, 1, 2, 3), 2), c(1, 1, 1, 2))
 })
 
+test_that("ids_per_plot: returns empty vector for empty ID set", {
+  expect_identical(ids_per_plot(c()), integer())
+})
+
 test_that("ids_per_plot: aborts if id_per_plot is below 1", {
   expect_error(
     ids_per_plot(1:12, id_per_plot = 0),
@@ -101,5 +158,14 @@ test_that("ids_per_plot: aborts if id_per_plot is below 1", {
   expect_error(
     ids_per_plot(1:12, id_per_plot = -1),
     "at least 1"
+  )
+})
+
+test_that("ids_per_plot: supports IDs with attributes", {
+  ids <- 1:12
+  attr(ids, "foo") <- "bar"
+  expect_identical(
+    ids_per_plot(id = ids, id_per_plot = 5),
+    c(1L, 1L, 1L, 1L, 1L, 2L, 2L, 2L, 2L, 2L, 3L, 3L)
   )
 })

--- a/tests/testthat/test-chunk.R
+++ b/tests/testthat/test-chunk.R
@@ -92,3 +92,14 @@ test_that("ids_per_plot special case: no error if more bins provided than values
   expect_equal(ids_per_plot(rep(letters[1:3], 2), 4), c(1, 1, 1, 1, 1, 1))
   expect_equal(ids_per_plot(c(1, 1, 2, 3), 2), c(1, 1, 1, 2))
 })
+
+test_that("ids_per_plot: aborts if id_per_plot is below 1", {
+  expect_error(
+    ids_per_plot(1:12, id_per_plot = 0),
+    "at least 1"
+  )
+  expect_error(
+    ids_per_plot(1:12, id_per_plot = -1),
+    "at least 1"
+  )
+})

--- a/tests/testthat/test-chunk.R
+++ b/tests/testthat/test-chunk.R
@@ -89,5 +89,6 @@ test_that("ids_per_plot expected output: IDs are sorted properly", {
 
 test_that("ids_per_plot special case: no error if more bins provided than values", {
   expect_equal(ids_per_plot(letters[1:3], 4), c(1, 1, 1))
+  expect_equal(ids_per_plot(rep(letters[1:3], 2), 4), c(1, 1, 1, 1, 1, 1))
   expect_equal(ids_per_plot(c(1, 1, 2, 3), 2), c(1, 1, 1, 2))
 })


### PR DESCRIPTION
This PR updates `ids_per_plot` to allow the `id` argument to have attributes (prompted by gh-67).  That main change is in the last commit.  The earlier commits make various more minor tweaks, the most notable one being adjusting the guard from gh-5 to return early and not bother with calculating bins.  See the commit messages for more details.

---

- [x] Wait for base to merge (#68)
