### PR TITLE
Release 0.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrgmisc
 Type: Package
 Title: MRG Helpers
-Version: 0.3.0.9002
+Version: 0.4.0
 Authors@R: c(
     person("Michael", "McDermott", email = "michaelm@metrumrg.com", role = c("aut", "cre")),
     person("Devin", "Pastoor", email = "devin.pastoor@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# mrgmisc 0.4.0
+
+## New features and changes
+
+- Replaced `geomean()` with `gm_mean()`, which supports configurable handling
+  of missing values and zeros. (#62)
+
+- Added `show_labels()` to display data-frame column names and labels. (#63)
+
+- Updated `ids_per_plot()` to support IDs with attributes and improved its
+  input validation and handling of edge cases. (#69)
+
+- Added `ghere()` to interpolate values into paths constructed with
+  `here::here()`. (#70)
+
+## Maintenance
+
+- Updated generated documentation and CI configuration, and raised the minimum
+  supported R version to 4.1.0. (#68)
+
+
 # mrgmisc 0.3.0
 
 - Added functions to render paths for various project needs


### PR DESCRIPTION
## Summary

- update the package version to 0.4.0
- document all merged changes since 0.3.0 in NEWS.md

## Release comparison

https://github.com/metrumresearchgroup/mrgmisc/compare/0.3.0...release/0.4.0

## Validation

- [x] `devtools::test()` (370 passing; 0 failures, warnings, or skips)